### PR TITLE
Suggestion to add Permission Policy and Worker note

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ if (inputRenderIndex !== input.length){
 
 ### Full API surface in Web IDL
 ```js
-[Exposed=(Window,Worker), SecureContext]
+[Exposed=Window, SecureContext]
 interface Proofreader {
   static Promise<Proofreader> create(optional ProofreaderCreateOptions options = {});
   static Promise<AIAvailability> availability(optional ProofreaderCreateCoreOptions options = {});
@@ -304,6 +304,18 @@ enum CorrectionType {
   "grammar"
 };
 ```
+
+## Permissions policy, iframes, and workers
+
+By default, this API is only available to top-level `Window`s, and to their same-origin iframes. Access to the API can be delegated to cross-origin iframes using the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) `allow=""` attribute:
+
+```html
+<iframe src="https://example.com/" allow="proofreader"></iframe>
+```
+
+This API is currently not available in workers, due to the complexity of establishing a responsible document for each worker in order to check the permissions policy status. See [this discussion](https://github.com/webmachinelearning/translation-api/issues/18#issuecomment-2705630392) for more. It may be possible to loosen this restriction over time, if use cases arise.
+
+Note that although the API is not exposed to web platform workers, a browser could expose them to extension service workers, which are outside the scope of web platform specifications and have a different permissions model.
 
 ## Alternatives considered and under consideration
 


### PR DESCRIPTION
Analog to the other APIs (e.g., the [Prompt API](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#permissions-policy-iframes-and-workers)), this API will likely integrate with Permission Policy.